### PR TITLE
Small change to fix selenium not stopping on mac os 10.11.5

### DIFF
--- a/classes/WPCC/CLI/Selenium.php
+++ b/classes/WPCC/CLI/Selenium.php
@@ -66,7 +66,7 @@ class Selenium extends \WP_CLI_Command {
 		$pids = trim( shell_exec( "pgrep -l -f {$selenium}" ) );
 		$pids = explode( PHP_EOL, (string) $pids );
 
-		if ( ! empty( $pids ) && count( $pids ) > 1 ) {
+		if ( ! empty( $pids ) && count( $pids ) >= 1 ) {
 			foreach ( $pids as $pid ) {
 				shell_exec( "kill -15 {$pid} > /dev/null 2>/dev/null" );
 			}


### PR DESCRIPTION
@eugene-manuilov Please review.

It turns out when selenium is installed on mac it doesn't create multiple pids like on ubuntu/vvv. This fixes the problem.
